### PR TITLE
Fix switch statement in Borrower.cs and remove stray line

### DIFF
--- a/Bibliotek/Borrower.cs
+++ b/Bibliotek/Borrower.cs
@@ -31,7 +31,7 @@ namespace Bibliotek
                     break;
                 default:
                     Console.WriteLine("Ogiltigt val.");
-               master
+                    break;
             }
         }
     }


### PR DESCRIPTION
Fix switch statement in Borrower.cs and remove stray line

Added a missing `break;` statement in the `default` case of a
`switch` statement to ensure proper termination. Removed an
unrelated or mistakenly included line (`master`) to improve
code clarity and correctness.